### PR TITLE
 Fix modulerefs (refs #510)

### DIFF
--- a/Xwt.Gtk/Xwt.Gtk3.dll.config
+++ b/Xwt.Gtk/Xwt.Gtk3.dll.config
@@ -8,6 +8,7 @@
 	<dllmap os="!windows,osx" dll="libpango-1.0-0.dll" target="libpango-1.0.so.0"/>
 	<dllmap os="!windows,osx" dll="libpangocairo-1.0-0.dll" target="libpangocairo-1.0.so.0"/>
 	<dllmap os="!windows,osx" dll="libwebkitgtk-3.0-0.dll" target="libwebkitgtk-3.0.so.0"/>
+	<dllmap os="!windows,osx" dll="fontconfig" target="libfontconfig.so.1"/>
 
 	<dllmap os="osx" dll="libglib-2.0-0.dll" target="libglib-2.0.0.dylib"/>
 	<dllmap os="osx" dll="libgobject-2.0-0.dll" target="libgobject-2.0.0.dylib"/>
@@ -17,4 +18,5 @@
 	<dllmap os="osx" dll="libpango-1.0-0.dll" target="libpango-1.0.0.dylib"/>
 	<dllmap os="osx" dll="libpangocairo-1.0-0.dll" target="libpangocairo-1.0.0.dylib"/>
 	<dllmap os="osx" dll="libwebkitgtk-3.0-0.dll" target="libwebkitgtk-3.0.0.dylib"/>
+	<dllmap os="osx" dll="fontconfig" target="libfontconfig.1.dylib"/>
 </configuration>

--- a/Xwt.Gtk/Xwt.GtkBackend/FontBackendHandler.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/FontBackendHandler.cs
@@ -68,10 +68,10 @@ namespace Xwt.GtkBackend
 			return FontDescription.FromString (fontName + ", " + style + " " + weight + " " + stretch + " " + size.ToString (CultureInfo.InvariantCulture));
 		}
 
-		[System.Runtime.InteropServices.DllImport ("fontconfig")]
+		[System.Runtime.InteropServices.DllImport (GtkInterop.LIBFONTCONFIG)]
 		static extern bool FcConfigAppFontAddFile (System.IntPtr config, string fontPath);
 
-		[System.Runtime.InteropServices.DllImport (Xwt.GtkBackend.GtkInterop.LIBPANGOCAIRO)]
+		[System.Runtime.InteropServices.DllImport (GtkInterop.LIBPANGOCAIRO)]
 		static extern void pango_cairo_font_map_set_default (System.IntPtr fontmap);
 
 		public override bool RegisterFontFromFile (string fontPath)

--- a/Xwt.Gtk/Xwt.GtkBackend/GtkInterop.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/GtkInterop.cs
@@ -34,25 +34,22 @@ namespace Xwt.GtkBackend
 {
 	public static class GtkInterop
 	{
-		#if XWT_GTK3
-		internal const string LIBGTK          = "libgtk-3-0.dll";
 		internal const string LIBATK          = "libatk-1.0-0.dll";
 		internal const string LIBGLIB         = "libglib-2.0-0.dll";
-		internal const string LIBGDK          = "libgdk-3-0.dll";
 		internal const string LIBGOBJECT      = "libgobject-2.0-0.dll";
 		internal const string LIBPANGO        = "libpango-1.0-0.dll";
 		internal const string LIBPANGOCAIRO   = "libpangocairo-1.0-0.dll";
+		internal const string LIBFONTCONFIG   = "fontconfig";
+
+		#if XWT_GTK3
+		internal const string LIBGTK          = "libgtk-3-0.dll";
+		internal const string LIBGDK          = "libgdk-3-0.dll";
 		internal const string LIBGTKGLUE      = "gtksharpglue-3";
 		internal const string LIBGLIBGLUE     = "glibsharpglue-3";
 		internal const string LIBWEBKIT       = "libwebkitgtk-3.0-0.dll";
 		#else
 		internal const string LIBGTK          = "libgtk-win32-2.0-0.dll";
-		internal const string LIBATK          = "libatk-1.0-0.dll";
-		internal const string LIBGLIB         = "libglib-2.0-0.dll";
 		internal const string LIBGDK          = "libgdk-win32-2.0-0.dll";
-		internal const string LIBGOBJECT      = "libgobject-2.0-0.dll";
-		internal const string LIBPANGO        = "libpango-1.0-0.dll";
-		internal const string LIBPANGOCAIRO   = "libpangocairo-1.0-0.dll";
 		internal const string LIBGTKGLUE      = "gtksharpglue-2";
 		internal const string LIBGLIBGLUE     = "glibsharpglue-2";
 		internal const string LIBWEBKIT       = "libwebkitgtk-1.0-0.dll";


### PR DESCRIPTION
Hi,

referring to your PR at mono/xwt#510, I've added the missing Gtk3 config and did some GtkInterop optimization. `Font.RegisterFontFromFile()` and other Font things work like a charm with Gtk3 now.
